### PR TITLE
modified bootstrap.sh to make it more helpful

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -20,9 +20,5 @@ printf "${YEL}Bootstrapping Mozilla Repo...\n" &&
 printf "${GRE}\n" &&
 tput sgr0 &&
 
-mkdir -p /c/mozilla-source/ &&
-cd /c/mozilla-source/ &&
-
-curl https://hg.mozilla.org/mozilla-central/raw-file/default/python/mozboot/bin/bootstrap.py -O &&
-python3 bootstrap.py
-
+[ -f bootstrap.py ] || curl https://hg.mozilla.org/mozilla-central/raw-file/default/python/mozboot/bin/bootstrap.py -O bootstrap.py
+python3 bootstrap.py "$@"


### PR DESCRIPTION
what I did is 
- removed the `mkdir /c` stuff, it's not needed
- curl the bootstrap.py script only if it's not present
- make it so that every argument that is passed to `bootstrap.sh` is passed to `bootstrap.py` (in my investigations I found out that bootstrap.py has some interesting flags)
