### PR TITLE
Add StartupWMClass to .desktop file

### DIFF
--- a/dist/usr/share/applications/mercury-browser.desktop
+++ b/dist/usr/share/applications/mercury-browser.desktop
@@ -13,6 +13,7 @@ Icon=mercury
 Categories=GNOME;GTK;Network;WebBrowser;
 MimeType=text/html;text/xml;application/xhtml+xml;application/xml;application/rss+xml;application/rdf+xml;image/gif;image/jpeg;image/png;x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/ftp;x-scheme-handler/chrome;video/webm;application/x-xpinstall;
 StartupNotify=true
+StartupWMClass=mercury-default
 Actions=NewWindow;NewPrivateWindow;TempUserDir;
 
 [Desktop Action NewWindow]


### PR DESCRIPTION
Added StartupWMClass to .desktop file to improve behaviour, when launching from pin on taskbar/dock on various desktop environments.