### PR TITLE
Update context.py

### DIFF
--- a/mozconfigs/context.py
+++ b/mozconfigs/context.py
@@ -2214,6 +2214,12 @@ VARIABLES = {
         """List of manifest files defining marionette-layout tests.
         """,
     ),
+    "MARIONETTE_MANIFESTS": (
+        ManifestparserManifestList,
+        list,
+        """List of manifest files defining marionette tests.
+        """,
+    ),
     "MARIONETTE_UNIT_MANIFESTS": (
         ManifestparserManifestList,
         list,


### PR DESCRIPTION
Adds in the `MARIONETTE_MANIFESTS` value to satisfy the compiler when building `cross-avx2` configuration. Provides a fix to #135.