### PR TITLE
Update RUSTFLAGS for AVX2

### DIFF
--- a/mozconfigs/mozconfig-avx2
+++ b/mozconfigs/mozconfig-avx2
@@ -104,5 +104,5 @@ export CPPFLAGS="-O3 -ffp-contract=fast -march=x86-64-v3"
 export CXXFLAGS="-O3 -ffp-contract=fast -march=x86-64-v3"
 export LDFLAGS="-Wl,-O3 -Wl,-mllvm,-fp-contract=fast -march=x86-64-v3"
 #export MOZ_LTO_LDFLAGS="-Wl,-mllvm,-polly"
-export RUSTFLAGS="-C target-feature=+avx2"
+export RUSTFLAGS="-C target-cpu=x86-64-v3 -C target-feature=+avx2 -C codegen-units=1"
 export VERBOSE=1

--- a/mozconfigs/mozconfig-avx2
+++ b/mozconfigs/mozconfig-avx2
@@ -104,5 +104,5 @@ export CPPFLAGS="-O3 -ffp-contract=fast -march=x86-64-v3"
 export CXXFLAGS="-O3 -ffp-contract=fast -march=x86-64-v3"
 export LDFLAGS="-Wl,-O3 -Wl,-mllvm,-fp-contract=fast -march=x86-64-v3"
 #export MOZ_LTO_LDFLAGS="-Wl,-mllvm,-polly"
-export RUSTFLAGS="-C target-cpu=x86-64-v3 -C target-feature=+avx2,+fma -C codegen-units=1"
+export RUSTFLAGS="-Ctarget-cpu=x86-64-v3 -Ctarget-feature=+avx2 -Ccodegen-units=1"
 export VERBOSE=1

--- a/mozconfigs/mozconfig-avx2
+++ b/mozconfigs/mozconfig-avx2
@@ -104,5 +104,5 @@ export CPPFLAGS="-O3 -ffp-contract=fast -march=x86-64-v3"
 export CXXFLAGS="-O3 -ffp-contract=fast -march=x86-64-v3"
 export LDFLAGS="-Wl,-O3 -Wl,-mllvm,-fp-contract=fast -march=x86-64-v3"
 #export MOZ_LTO_LDFLAGS="-Wl,-mllvm,-polly"
-export RUSTFLAGS="-C target-cpu=x86-64-v3 -C target-feature=+avx2 -C codegen-units=1"
+export RUSTFLAGS="-C target-cpu=x86-64-v3 -C target-feature=+avx2,+fma -C codegen-units=1"
 export VERBOSE=1

--- a/mozconfigs/mozconfig-win-avx2
+++ b/mozconfigs/mozconfig-win-avx2
@@ -110,5 +110,5 @@ export CPPFLAGS="-O3 -march=x86-64-v3 /clang:-O3 /clang:-ffp-contract=fast /arch
 export CXXFLAGS="-O3 -march=x86-64-v3 /clang:-O3 /clang:-ffp-contract=fast /arch:AVX2"
 export LDFLAGS="-Wl,-O3 -march=x86-64-v3"
 POLLY="-mllvm -polly -mllvm -polly-2nd-level-tiling -mllvm -polly-loopfusion-greedy -mllvm -polly-pattern-matching-based-opts -mllvm -polly-position=before-vectorizer -mllvm -polly-vectorizer=stripmine"
-export RUSTFLAGS="-C target-cpu=haswell -C target-feature=+avx2,+fma -C codegen-units=1"
+export RUSTFLAGS="-Ctarget-cpu=haswell -Ctarget-feature=+avx2 -Ccodegen-units=1"
 export VERBOSE=1

--- a/mozconfigs/mozconfig-win-avx2
+++ b/mozconfigs/mozconfig-win-avx2
@@ -110,5 +110,5 @@ export CPPFLAGS="-O3 -march=x86-64-v3 /clang:-O3 /clang:-ffp-contract=fast /arch
 export CXXFLAGS="-O3 -march=x86-64-v3 /clang:-O3 /clang:-ffp-contract=fast /arch:AVX2"
 export LDFLAGS="-Wl,-O3 -march=x86-64-v3"
 POLLY="-mllvm -polly -mllvm -polly-2nd-level-tiling -mllvm -polly-loopfusion-greedy -mllvm -polly-pattern-matching-based-opts -mllvm -polly-position=before-vectorizer -mllvm -polly-vectorizer=stripmine"
-export RUSTFLAGS="-C target-cpu=haswell -C target-feature=+avx2 -C codegen-units=1"
+export RUSTFLAGS="-C target-cpu=haswell -C target-feature=+avx2,+fma -C codegen-units=1"
 export VERBOSE=1

--- a/mozconfigs/mozconfig-win-avx2
+++ b/mozconfigs/mozconfig-win-avx2
@@ -110,5 +110,5 @@ export CPPFLAGS="-O3 -march=x86-64-v3 /clang:-O3 /clang:-ffp-contract=fast /arch
 export CXXFLAGS="-O3 -march=x86-64-v3 /clang:-O3 /clang:-ffp-contract=fast /arch:AVX2"
 export LDFLAGS="-Wl,-O3 -march=x86-64-v3"
 POLLY="-mllvm -polly -mllvm -polly-2nd-level-tiling -mllvm -polly-loopfusion-greedy -mllvm -polly-pattern-matching-based-opts -mllvm -polly-position=before-vectorizer -mllvm -polly-vectorizer=stripmine"
-export RUSTFLAGS="-C target-feature=+avx2"
+export RUSTFLAGS="-C target-cpu=x86-64-v3 -C target-feature=+avx2 -C codegen-units=1"
 export VERBOSE=1

--- a/mozconfigs/mozconfig-win-avx2
+++ b/mozconfigs/mozconfig-win-avx2
@@ -110,5 +110,5 @@ export CPPFLAGS="-O3 -march=x86-64-v3 /clang:-O3 /clang:-ffp-contract=fast /arch
 export CXXFLAGS="-O3 -march=x86-64-v3 /clang:-O3 /clang:-ffp-contract=fast /arch:AVX2"
 export LDFLAGS="-Wl,-O3 -march=x86-64-v3"
 POLLY="-mllvm -polly -mllvm -polly-2nd-level-tiling -mllvm -polly-loopfusion-greedy -mllvm -polly-pattern-matching-based-opts -mllvm -polly-position=before-vectorizer -mllvm -polly-vectorizer=stripmine"
-export RUSTFLAGS="-C target-cpu=x86-64-v3 -C target-feature=+avx2 -C codegen-units=1"
+export RUSTFLAGS="-C target-cpu=haswell -C target-feature=+avx2 -C codegen-units=1"
 export VERBOSE=1

--- a/mozconfigs/mozconfig-win-avx2-cross
+++ b/mozconfigs/mozconfig-win-avx2-cross
@@ -108,5 +108,5 @@ export CPPFLAGS="-march=x86-64-v3 /clang:-O3 /clang:-ffp-contract=fast"
 export CXXFLAGS="-march=x86-64-v3 /clang:-O3 /clang:-ffp-contract=fast"
 export LDFLAGS="-Wl,-O3 -march=x86-64-v3"
 #export MOZ_LTO_LDFLAGS="-Wl,-mllvm,-polly"
-export RUSTFLAGS="-C target-feature=+avx2"
+export RUSTFLAGS="-C target-cpu=x86-64-v3 -C target-feature=+avx2 -C codegen-units=1"
 export VERBOSE=1

--- a/mozconfigs/mozconfig-win-avx2-cross
+++ b/mozconfigs/mozconfig-win-avx2-cross
@@ -108,5 +108,5 @@ export CPPFLAGS="-march=x86-64-v3 /clang:-O3 /clang:-ffp-contract=fast"
 export CXXFLAGS="-march=x86-64-v3 /clang:-O3 /clang:-ffp-contract=fast"
 export LDFLAGS="-Wl,-O3 -march=x86-64-v3"
 #export MOZ_LTO_LDFLAGS="-Wl,-mllvm,-polly"
-export RUSTFLAGS="-C target-cpu=x86-64-v3 -C target-feature=+avx2 -C codegen-units=1"
+export RUSTFLAGS="-C target-cpu=haswell -C target-feature=+avx2 -C codegen-units=1"
 export VERBOSE=1

--- a/mozconfigs/mozconfig-win-avx2-cross
+++ b/mozconfigs/mozconfig-win-avx2-cross
@@ -108,5 +108,5 @@ export CPPFLAGS="-march=x86-64-v3 /clang:-O3 /clang:-ffp-contract=fast"
 export CXXFLAGS="-march=x86-64-v3 /clang:-O3 /clang:-ffp-contract=fast"
 export LDFLAGS="-Wl,-O3 -march=x86-64-v3"
 #export MOZ_LTO_LDFLAGS="-Wl,-mllvm,-polly"
-export RUSTFLAGS="-C target-cpu=haswell -C target-feature=+avx2,+fma -C codegen-units=1"
+export RUSTFLAGS="-Ctarget-cpu=haswell -Ctarget-feature=+avx2 -Ccodegen-units=1"
 export VERBOSE=1

--- a/mozconfigs/mozconfig-win-avx2-cross
+++ b/mozconfigs/mozconfig-win-avx2-cross
@@ -108,5 +108,5 @@ export CPPFLAGS="-march=x86-64-v3 /clang:-O3 /clang:-ffp-contract=fast"
 export CXXFLAGS="-march=x86-64-v3 /clang:-O3 /clang:-ffp-contract=fast"
 export LDFLAGS="-Wl,-O3 -march=x86-64-v3"
 #export MOZ_LTO_LDFLAGS="-Wl,-mllvm,-polly"
-export RUSTFLAGS="-C target-cpu=haswell -C target-feature=+avx2 -C codegen-units=1"
+export RUSTFLAGS="-C target-cpu=haswell -C target-feature=+avx2,+fma -C codegen-units=1"
 export VERBOSE=1


### PR DESCRIPTION
codegen-units can be used in other configs as well, but that's up to your discretion

(Please update Rust to 1.77)