### PR TITLE
Change executable name to avoid CPU bug

### DIFF
--- a/mozconfigs/mozconfig
+++ b/mozconfigs/mozconfig
@@ -72,7 +72,7 @@ ac_add_options --with-google-location-service-api-keyfile=@TOPSRCDIR@/ga
 ac_add_options --with-google-safebrowsing-api-keyfile=@TOPSRCDIR@/ga
 
 # Branding
-ac_add_options --with-app-name=mercury
+ac_add_options --with-app-name=mercurybrowser
 ac_add_options --with-app-basename=Mercury
 ac_add_options --with-branding=browser/branding/mercury
 ac_add_options --with-l10n-base=$PWD/browser/locales/en-US

--- a/mozconfigs/mozconfig-arm64
+++ b/mozconfigs/mozconfig-arm64
@@ -70,7 +70,7 @@ ac_add_options --with-google-location-service-api-keyfile=@TOPSRCDIR@/ga
 ac_add_options --with-google-safebrowsing-api-keyfile=@TOPSRCDIR@/ga
 
 # Branding
-ac_add_options --with-app-name=mercury
+ac_add_options --with-app-name=mercurybrowser
 ac_add_options --with-app-basename=Mercury
 ac_add_options --with-branding=browser/branding/mercury
 ac_add_options --with-l10n-base=$PWD/browser/locales/en-US

--- a/mozconfigs/mozconfig-avx2
+++ b/mozconfigs/mozconfig-avx2
@@ -73,7 +73,7 @@ ac_add_options --with-google-location-service-api-keyfile=@TOPSRCDIR@/ga
 ac_add_options --with-google-safebrowsing-api-keyfile=@TOPSRCDIR@/ga
 
 # Branding
-ac_add_options --with-app-name=mercury
+ac_add_options --with-app-name=mercurybrowser
 ac_add_options --with-app-basename=Mercury
 ac_add_options --with-branding=browser/branding/mercury
 ac_add_options --with-l10n-base=$PWD/browser/locales/en-US

--- a/mozconfigs/mozconfig-debug
+++ b/mozconfigs/mozconfig-debug
@@ -55,7 +55,7 @@ ac_add_options --with-google-location-service-api-keyfile=@TOPSRCDIR@/ga
 ac_add_options --with-google-safebrowsing-api-keyfile=@TOPSRCDIR@/ga
 
 # Branding
-ac_add_options --with-app-name=mercury
+ac_add_options --with-app-name=mercurybrowser
 ac_add_options --with-app-basename=Mercury
 ac_add_options --with-branding=browser/branding/mercury
 ac_add_options --with-l10n-base=$PWD/browser/locales/en-US

--- a/mozconfigs/mozconfig-macos-arm64
+++ b/mozconfigs/mozconfig-macos-arm64
@@ -66,7 +66,7 @@ ac_add_options --with-google-location-service-api-keyfile=@TOPSRCDIR@/ga
 ac_add_options --with-google-safebrowsing-api-keyfile=@TOPSRCDIR@/ga
 
 # Branding
-ac_add_options --with-app-name=mercury
+ac_add_options --with-app-name=mercurybrowser
 ac_add_options --with-app-basename=Mercury
 ac_add_options --with-branding=browser/branding/mercury
 ac_add_options --with-l10n-base=$PWD/browser/locales/en-US

--- a/mozconfigs/mozconfig-macos-arm64-cross
+++ b/mozconfigs/mozconfig-macos-arm64-cross
@@ -68,7 +68,7 @@ ac_add_options --with-google-location-service-api-keyfile=@TOPSRCDIR@/ga
 ac_add_options --with-google-safebrowsing-api-keyfile=@TOPSRCDIR@/ga
 
 # Branding
-ac_add_options --with-app-name=mercury
+ac_add_options --with-app-name=mercurybrowser
 ac_add_options --with-app-basename=Mercury
 ac_add_options --with-branding=browser/branding/mercury
 ac_add_options --with-l10n-base=$PWD/browser/locales/en-US

--- a/mozconfigs/mozconfig-macos-x64
+++ b/mozconfigs/mozconfig-macos-x64
@@ -68,7 +68,7 @@ ac_add_options --with-google-location-service-api-keyfile=@TOPSRCDIR@/ga
 ac_add_options --with-google-safebrowsing-api-keyfile=@TOPSRCDIR@/ga
 
 # Branding
-ac_add_options --with-app-name=mercury
+ac_add_options --with-app-name=mercurybrowser
 ac_add_options --with-app-basename=Mercury
 ac_add_options --with-branding=browser/branding/mercury
 ac_add_options --with-l10n-base=$PWD/browser/locales/en-US

--- a/mozconfigs/mozconfig-macos-x64-cross
+++ b/mozconfigs/mozconfig-macos-x64-cross
@@ -70,7 +70,7 @@ ac_add_options --with-google-location-service-api-keyfile=@TOPSRCDIR@/ga
 ac_add_options --with-google-safebrowsing-api-keyfile=@TOPSRCDIR@/ga
 
 # Branding
-ac_add_options --with-app-name=mercury
+ac_add_options --with-app-name=mercurybrowser
 ac_add_options --with-app-basename=Mercury
 ac_add_options --with-branding=browser/branding/mercury
 ac_add_options --with-l10n-base=$PWD/browser/locales/en-US

--- a/mozconfigs/mozconfig-sse3
+++ b/mozconfigs/mozconfig-sse3
@@ -72,7 +72,7 @@ ac_add_options --with-google-location-service-api-keyfile=@TOPSRCDIR@/ga
 ac_add_options --with-google-safebrowsing-api-keyfile=@TOPSRCDIR@/ga
 
 # Branding
-ac_add_options --with-app-name=mercury
+ac_add_options --with-app-name=mercurybrowser
 ac_add_options --with-app-basename=Mercury
 ac_add_options --with-branding=browser/branding/mercury
 ac_add_options --with-l10n-base=$PWD/browser/locales/en-US

--- a/mozconfigs/mozconfig-sse4
+++ b/mozconfigs/mozconfig-sse4
@@ -72,7 +72,7 @@ ac_add_options --with-google-location-service-api-keyfile=@TOPSRCDIR@/ga
 ac_add_options --with-google-safebrowsing-api-keyfile=@TOPSRCDIR@/ga
 
 # Branding
-ac_add_options --with-app-name=mercury
+ac_add_options --with-app-name=mercurybrowser
 ac_add_options --with-app-basename=Mercury
 ac_add_options --with-branding=browser/branding/mercury
 ac_add_options --with-l10n-base=$PWD/browser/locales/en-US

--- a/mozconfigs/mozconfig-win
+++ b/mozconfigs/mozconfig-win
@@ -75,7 +75,7 @@ ac_add_options --with-google-location-service-api-keyfile=@TOPSRCDIR@/ga
 ac_add_options --with-google-safebrowsing-api-keyfile=@TOPSRCDIR@/ga
 
 # Branding
-ac_add_options --with-app-name=mercury
+ac_add_options --with-app-name=mercurybrowser
 ac_add_options --with-app-basename=Mercury
 ac_add_options --with-branding=browser/branding/mercury
 ac_add_options --with-l10n-base="C:\mozilla-source\mozilla-unified\browser\locales\en-US"

--- a/mozconfigs/mozconfig-win-avx2
+++ b/mozconfigs/mozconfig-win-avx2
@@ -75,7 +75,7 @@ ac_add_options --with-google-location-service-api-keyfile=@TOPSRCDIR@/ga
 ac_add_options --with-google-safebrowsing-api-keyfile=@TOPSRCDIR@/ga
 
 # Branding
-ac_add_options --with-app-name=mercury
+ac_add_options --with-app-name=mercurybrowser
 ac_add_options --with-app-basename=Mercury
 ac_add_options --with-branding=browser/branding/mercury
 ac_add_options --with-l10n-base="C:\mozilla-source\mozilla-unified\browser\locales\en-US"

--- a/mozconfigs/mozconfig-win-avx2-cross
+++ b/mozconfigs/mozconfig-win-avx2-cross
@@ -82,7 +82,7 @@ ac_add_options --with-google-location-service-api-keyfile=@TOPSRCDIR@/ga
 ac_add_options --with-google-safebrowsing-api-keyfile=@TOPSRCDIR@/ga
 
 # Branding
-ac_add_options --with-app-name=mercury
+ac_add_options --with-app-name=mercurybrowser
 ac_add_options --with-app-basename=Mercury
 ac_add_options --with-branding=browser/branding/mercury
 ac_add_options --with-l10n-base=$PWD/browser/locales/en-US

--- a/mozconfigs/mozconfig-win-cross
+++ b/mozconfigs/mozconfig-win-cross
@@ -82,7 +82,7 @@ ac_add_options --with-google-location-service-api-keyfile=@TOPSRCDIR@/ga
 ac_add_options --with-google-safebrowsing-api-keyfile=@TOPSRCDIR@/ga
 
 # Branding
-ac_add_options --with-app-name=mercury
+ac_add_options --with-app-name=mercurybrowser
 ac_add_options --with-app-basename=Mercury
 ac_add_options --with-branding=browser/branding/mercury
 ac_add_options --with-l10n-base=$PWD/browser/locales/en-US

--- a/mozconfigs/mozconfig-win-debug
+++ b/mozconfigs/mozconfig-win-debug
@@ -63,7 +63,7 @@ ac_add_options --with-google-location-service-api-keyfile=@TOPSRCDIR@/ga
 ac_add_options --with-google-safebrowsing-api-keyfile=@TOPSRCDIR@/ga
 
 # Branding
-ac_add_options --with-app-name=mercury
+ac_add_options --with-app-name=mercurybrowser
 ac_add_options --with-app-basename=Mercury
 ac_add_options --with-branding=browser/branding/mercury
 ac_add_options --with-l10n-base="C:\mozilla-source\mozilla-unified\browser\locales\en-US"

--- a/mozconfigs/mozconfig-win-sse3
+++ b/mozconfigs/mozconfig-win-sse3
@@ -75,7 +75,7 @@ ac_add_options --with-google-location-service-api-keyfile=@TOPSRCDIR@/ga
 ac_add_options --with-google-safebrowsing-api-keyfile=@TOPSRCDIR@/ga
 
 # Branding
-ac_add_options --with-app-name=mercury
+ac_add_options --with-app-name=mercurybrowser
 ac_add_options --with-app-basename=Mercury
 ac_add_options --with-branding=browser/branding/mercury
 ac_add_options --with-l10n-base="C:\mozilla-source\mozilla-unified\browser\locales\en-US"

--- a/mozconfigs/mozconfig-win-sse4
+++ b/mozconfigs/mozconfig-win-sse4
@@ -75,7 +75,7 @@ ac_add_options --with-google-location-service-api-keyfile=@TOPSRCDIR@/ga
 ac_add_options --with-google-safebrowsing-api-keyfile=@TOPSRCDIR@/ga
 
 # Branding
-ac_add_options --with-app-name=mercury
+ac_add_options --with-app-name=mercurybrowser
 ac_add_options --with-app-basename=Mercury
 ac_add_options --with-branding=browser/branding/mercury
 ac_add_options --with-l10n-base="C:\mozilla-source\mozilla-unified\browser\locales\en-US"


### PR DESCRIPTION
To avoid the high CPU bug observed in #185, the branding in the mozconfig files has been changed to `mercurybrowser` instead of `mercury`. The rest of the branding should remain intact, but the `exe` file will be named `mercurybrowser.exe` instead of `mercury.exe`, which was conflicting with the Gotham Knights application profile with Nvidia.